### PR TITLE
Document necessary permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,36 @@ Proof of concept workaround needed until FOLIO supports importing MARC records t
 * I've included example MARC files but you will have to update them with your vendor, fund, object codes
 * The first call is a bit slow because it initializes reference values/UUIDs
 
+
+### Permissions
+This app requires a FOLIO user account with the following permissions granted:
+
+* `finance.budgets.collection.get`
+* `finance.funds.collection.get`
+* `inventory-storage.classification-types.collection.get`
+* `inventory-storage.contributor-name-types.collection.get`
+* `inventory-storage.contributor-types.collection.get`
+* `inventory-storage.holdings-types.collection.get`
+* `inventory-storage.holdings.collection.get`
+* `inventory-storage.holdings.item.put`
+* `inventory-storage.identifier-types.collection.get`
+* `inventory-storage.instance-types.collection.get`
+* `inventory-storage.loan-types.collection.get`
+* `inventory-storage.locations.collection.get`
+* `inventory-storage.material-types.collection.get`
+* `inventory.all`
+* `note.types.allops`
+* `notes.domain.all`
+* `notes.item.post`
+* `orders.acquisitions-units-assignments.assign`
+* `orders.all`
+* `orders.item.approve`
+* `organizations-storage.organizations.collection.get`
+* `source-storage.records.post`
+* `source-storage.snapshots.post`
+* `tags.collection.get`
+* `ui-orders.order.create`
+
 ### Lots of areas for improvement including:
 * Better way to get data out of the MARC record to include on the instance. 
 * Better way to store reference values needed for lookup


### PR DESCRIPTION
@starsplatter These are the permissions currently in the `machine-users_order-import` permission set on both `cornell-test` and `cornell-training`. We can tweak as needed once you've had chance to put it through its paces.

### Edge cases
Permissions were fleshed out via good ole trial and error, starting off with a permission set for our user that had no sub permissions defined. Most were straightforward and clearly reported via API responses, but there were some interesting edge cases:

1. [`orders.acquisitions-units-assignments.item.post`](https://s3.amazonaws.com/foliodocs/api/mod-orders/order.html#orders_composite_orders_post)
1. [`orders.item.approve`](https://github.com/folio-org/mod-orders/blob/e4e24c2c2e224aa52d59a6977eb46d3b1ae85ec9/README.md#additional-permissions-required)
1. [`note.types.collection.get`](https://github.com/folio-org/mod-notes/blob/fadc9ff3f86a745b0452f4cfdb5dfadb7493ca3f/descriptors/ModuleDescriptor-template.json#L46-L50)
   > doesn't exist so had to use `note.types.allops` which has `note.types.collection.get` listed as a subPermission 🤷🏼 