### PR TITLE
Document new permission requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Proof of concept workaround needed until FOLIO supports importing MARC records t
 This app requires a FOLIO user account with the following permissions granted:
 
 * `finance.budgets.collection.get`
+* `finance.fiscal-years.collection.get`
 * `finance.funds.collection.get`
 * `inventory-storage.classification-types.collection.get`
 * `inventory-storage.contributor-name-types.collection.get`


### PR DESCRIPTION
As per @fereira's request:

> I've got a test case that'll query for a fiscalYear record based on the
current date but it looks like the user credentials requires an
additional permision:
>
> ```
> Access requires permission: finance.fiscal-years.collection.get
> ```