### PR TITLE
Identifiers & contributors for PO line; vendorCode & ISBN for response

### DIFF
--- a/src/main/java/org/olf/folio/order/MarcToJson.java
+++ b/src/main/java/org/olf/folio/order/MarcToJson.java
@@ -273,6 +273,14 @@ public class MarcToJson {
     public JSONArray run() throws Exception {          
  
         String materialTypeName = "Book";
+        String ISBNId = this.lookupTable.get("ISBN");
+        String invalidISBN = this.lookupTable.get("Invalid ISBN");
+        String personalNameTypeId = this.lookupTable.get("Personal name");
+        
+        logger.info("Personal name: "+ personalNameTypeId);
+        logger.info("ISBN: "+ ISBNId);
+        logger.info("Invalid ISBN: "+ invalidISBN);
+        
         JSONArray responseMessages = new JSONArray();        
         JSONArray errorMessages = new JSONArray();
         // GENERATE UUID for the PO 
@@ -427,14 +435,52 @@ public class MarcToJson {
                 if (StringUtils.isNotEmpty(receivingNote)) {
                     detailsObject.put("receivingNote", receivingNote);
                 }
-                // get ISBN values in a productIds array and add to detailsObject if not empty
-                JSONArray productIds = marcUtils.getISBN(record, lookupTable.get("ISBN"));
-                if (productIds.length() > 0) {
-                    detailsObject.put("productIds", productIds);
-                }
                 
+                // get ISBN values in a productIds array and add to detailsObject if not empty
+                //JSONArray productIds = marcUtils.getISBN(record, ISBNId, invalidISBN);
+                JSONArray productIds = new JSONArray();
+                JSONArray identifiers = marcUtils.buildIdentifiers(record, lookupTable);
+                Iterator identIter = identifiers.iterator();
+                while (identIter.hasNext()) {
+                    JSONObject identifierObj = (JSONObject) identIter.next();
+                    String identifierType = identifierObj.getString("identifierTypeId");
+                    String oldVal = identifierObj.getString("value");
+                    //if (identifierType.equals(ISBNId)) {
+                        JSONObject productId = new JSONObject();
+                        String newVal = StringUtils.substringBefore(oldVal, " ");
+                        String qualifier = StringUtils.substringAfter(oldVal, " ");
+                        productId.put("productId", newVal);
+                        productId.put("productIdType", identifierType);
+                        if (StringUtils.isNotEmpty(qualifier)) {
+                            productId.put("qualifier", qualifier);
+                        }
+                        productIds.put(productId);
+                   //}
+                    
+                }
+                if (productIds.length() > 0) {
+                    logger.info(productIds.toString(3));
+                    detailsObject.put("productIds", productIds);
+                }                  
                 if (! detailsObject.isEmpty()) {
                     orderLine.put("details", detailsObject);   
+                }
+                
+                // add contributors
+                JSONArray contribArray = new JSONArray();
+                 
+                JSONArray contributors = marcUtils.buildContributors(record, lookupTable);
+                Iterator contribIter = contributors.iterator();
+                while (contribIter.hasNext()) {
+                    JSONObject contribObj = (JSONObject) contribIter.next();
+                    JSONObject contribCopyObj = new JSONObject();
+                    contribCopyObj.put("contributorNameTypeId", personalNameTypeId);
+                    contribCopyObj.put("contributor", contribObj.get("name"));
+                    contribArray.put(contribCopyObj);
+                }
+                if (contribArray.length() > 0) {
+                    orderLine.put("contributors", contribArray);
+                    logger.debug(contribArray.toString(3));
                 }
                 
                 // get rush value

--- a/src/main/java/org/olf/folio/order/MarcToJson.java
+++ b/src/main/java/org/olf/folio/order/MarcToJson.java
@@ -420,12 +420,21 @@ public class MarcToJson {
                     orderLine.put("description", internalNotes);
                 }
                 
+                // add a detailsObject if a receiving note or ISBN identifiers are found
+                JSONObject detailsObject = new JSONObject();
                 // get the "receiving note"
                 String receivingNote =  marcUtils.getReceivingNote(nineEightyOne);
                 if (StringUtils.isNotEmpty(receivingNote)) {
-                    JSONObject detailsObject = new JSONObject();
                     detailsObject.put("receivingNote", receivingNote);
-                    orderLine.put("details", detailsObject);
+                }
+                // get ISBN values in a productIds array and add to detailsObject if not empty
+                JSONArray productIds = marcUtils.getISBN(record, lookupTable.get("ISBN"));
+                if (productIds.length() > 0) {
+                    detailsObject.put("productIds", productIds);
+                }
+                
+                if (! detailsObject.isEmpty()) {
+                    orderLine.put("details", detailsObject);   
                 }
                 
                 // get rush value

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -374,7 +374,6 @@ public class OrderImport {
 		//POST THE ORDER AND LINE:
 		String orderResponse = apiService.callApiPostWithUtf8(baseOkapEndpoint + "orders/composite-orders", order, token);  
 		 
-		// get the updated order
 		
 		//GET THE UPDATED PURCHASE ORDER FROM THE API AND PULL OUT THE ID FOR THE INSTANCE FOLIO CREATED:
 		logger.debug("getUpdatedPurchaseOrder");

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -289,7 +289,6 @@ public class OrderImport {
                     productIds.put(productId); 
                     
                 }
-                // TODO: Fix but that causes 422 response if productIds are addet to details in poLine
                 if (productIds.length() > 0) {
                     logger.debug(productIds.toString(3));
                     detailsObject.put("productIds", productIds);

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -481,8 +481,6 @@ public class OrderImport {
 				JSONObject sourceRecordStorageObject = new JSONObject();
 				sourceRecordStorageObject.put("recordType", "MARC");
 				sourceRecordStorageObject.put("snapshotId", snapshotId.toString());
-				// TODO: this should be recordTableId.toString()
-				//sourceRecordStorageObject.put("matchedId", instanceId.toString()); 
 				sourceRecordStorageObject.put("matchedId", recordTableId.toString());
 				
 				//LINK THE INSTANCE TO SOURCE RECORD STORAGE

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -486,33 +486,6 @@ public class OrderImport {
 				JSONObject holdingsAsJson = new JSONObject(holdingResponse);
 				JSONObject holdingRecord = holdingsAsJson.getJSONArray("holdingsRecords").getJSONObject(0);
 				
-				// TODO: Do we need to include 856 fields now?
-				//JSONArray eResources = new JSONArray();
-				//String linkText = (String) getMyContext().getAttribute("textForElectronicResources");
-				
-				// TODO: clean this up...
-				//logger.debug("Add 856 fields");
-				//List urls =  record.getVariableFields("856");
-				//Iterator<DataField> iterator = urls.iterator();
-				//while (iterator.hasNext()) {
-				//	DataField dataField = (DataField) iterator.next();
-				//	if (dataField != null && dataField.getSubfield('u') != null) {
-				//		String url = dataField.getSubfield('u').getData();
-				//		if (dataField.getSubfield('z') != null) {
-				//			linkText = dataField.getSubfield('z').getData();
-				//		}
-				//		JSONObject eResource = new JSONObject();
-				//		eResource.put("uri", dataField.getSubfield('u').getData());
-				//		//TODO - DO WE WANT TO CHANGE THE LINK TEXT?
-				//		eResource.put("linkText", linkText);
-						//I 'THINK' THESE RELATIONSHIP TYPES ARE HARDCODED INTO FOLIO
-						//CANT BE LOOKED UP WITH AN API?
-						//https://github.com/folio-org/mod-inventory-storage/blob/master/reference-data/electronic-access-relationships/resource.json
-				//		eResource.put("relationshipId", "f5d0068e-6272-458e-8a81-b85e7b9a14aa");
-				//		eResources.put(eResource);
-				//	}
-				//}
-				
 				//UPDATE THE INSTANCE RECORD
 				logger.debug("Update Instance Record");
 				//instanceAsJson.put("electronicAccess", eResources);

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -42,7 +42,7 @@ public class OrderImport {
 	
 	private static final Logger logger = Logger.getLogger(OrderImport.class);
 	private ServletContext myContext;
-	private HashMap<String,String> lookupTable;
+	private HashMap<String, String> lookupTable;
 	private HashMap<String, String> billingMap;
 	private String tenant;
 	
@@ -79,10 +79,7 @@ public class OrderImport {
 		jsonObject.put("tenant",tenant);
 		
 		this.apiService = new ApiService(tenant);
-		String token = this.apiService.callApiAuth( baseOkapEndpoint + "authn/login",  jsonObject);	
-		
-		//TODO: REMOVE
-		logger.debug("TOKEN: " + token);  
+		String token = this.apiService.callApiAuth( baseOkapEndpoint + "authn/login",  jsonObject); 
 		
 		//GET THE UPLOADED FILE
 		String filePath = (String) myContext.getAttribute("uploadFilePath");
@@ -107,8 +104,7 @@ public class OrderImport {
 	   	JSONArray validateRequiredResult = validateRequiredValues(reader, token, baseOkapEndpoint);
 	   	if (!validateRequiredResult.isEmpty()) return validateRequiredResult;
 	   	
-		// SAVE REFERENCE TABLE VALUES (JUST LOOKUP THEM UP ONCE)
-	   	// TODO: move the creation of the lookupTable to the OrderController
+		//SAVE REFERENCE TABLE VALUES (JUST LOOKUP THEM UP ONCE)
 	   	logger.debug("Get Lookup table");
 		if (myContext.getAttribute(Constants.LOOKUP_TABLE) == null) {
 			 LookupUtil lookupUtil = new LookupUtil();
@@ -120,6 +116,8 @@ public class OrderImport {
 			 this.billingMap = lookupUtil.getBillingAddresses(billingEndpoint, token);
 			 myContext.setAttribute(Constants.LOOKUP_TABLE, lookupTable);
 			 myContext.setAttribute(Constants.BILLINGMAP, billingMap);
+			 
+			 
 			 logger.debug("put lookup table in context");
 		} else {
 			 this.lookupTable = (HashMap<String, String>) myContext.getAttribute(Constants.LOOKUP_TABLE);
@@ -127,6 +125,7 @@ public class OrderImport {
 			 logger.debug("got lookup table from context");
 		}
 		String ISBNId = this.lookupTable.get("ISBN");
+		String personalNameTypeId = this.lookupTable.get("Personal name");
 		
 		
 		// READ THE MARC RECORD FROM THE FILE
@@ -166,6 +165,9 @@ public class OrderImport {
 		
 		JSONArray poLines = new JSONArray();
 		
+		// map of records with orderline uuid as key
+		HashMap<String, Record> recordMap = new HashMap<String, Record>();
+		
 		// iterator over records in the marc file.
 	     
 		logger.debug("reading marc file");
@@ -182,7 +184,7 @@ public class OrderImport {
 			    DataField nineEightyOne = (DataField) record.getVariableField("981");
 			    DataField nineSixtyOne = (DataField) record.getVariableField("961");
 			    
-				String title = marcUtils.getTitle(twoFourFive);
+				String title = marcUtils.getTitle(twoFourFive);						 
 				String fundCode = marcUtils.getFundCode(nineEighty);
 				// vendor code instantiated outside of loop because it will be the same for all orderLines and added to response later
 				vendorCode =  marcUtils.getVendorCode(nineEighty);
@@ -191,8 +193,8 @@ public class OrderImport {
 				Integer quantityNo = 0; //INIT
 			    if (quantity != null)  quantityNo = Integer.valueOf(quantity);
 			    
-				String price = marcUtils.getPrice(nineEightyOne); 
-				String vendorItemId = marcUtils.getVendorItemId(nineSixtyOne);	    
+				String price = marcUtils.getPrice(nineEightyOne);
+				String vendorItemId = marcUtils.getVendorItemId(nineSixtyOne);
 			    String locationName = marcUtils.getLocation(nineFiveTwo);
 			    
 			     
@@ -202,10 +204,20 @@ public class OrderImport {
 				String orgLookupResponse = this.apiService.callApiGet(organizationEndpoint,  token);
 				JSONObject orgObject = new JSONObject(orgLookupResponse);
 				String vendorId = (String) orgObject.getJSONArray("organizations").getJSONObject(0).get("id");
-				order.put("vendor", vendorId);				 
 				
-				// Create an OrderLine
-				// FOLIO WILL CREATE THE INSTANCE, HOLDINGS, ITEM (IF PHYSICAL ITEM)
+				//LOOK UP THE FUND
+				//logger.debug("lookup Fund");
+				String fundEndpoint = baseOkapEndpoint + "finance/funds?limit=30&offset=0&query=((code='" + fundCode + "'))";
+				String fundResponse = this.apiService.callApiGet(fundEndpoint, token);
+				JSONObject fundsObject = new JSONObject(fundResponse);
+				String fundId = (String) fundsObject.getJSONArray("funds").getJSONObject(0).get("id");				
+				
+				// CREATING THE PURCHASE ORDER				
+				
+				order.put("vendor", vendorId);				
+				
+				// POST ORDER LINE
+				//FOLIO WILL CREATE THE INSTANCE, HOLDINGS, ITEM (IF PHYSICAL ITEM)
 				JSONObject orderLine = new JSONObject();
 				JSONObject cost = new JSONObject();
 				JSONObject location = new JSONObject();
@@ -239,6 +251,8 @@ public class OrderImport {
                 }
 				
 				UUID orderLineUUID = UUID.randomUUID();
+				// save the record
+				recordMap.put(orderLineUUID.toString(), record);
 				orderLine.put("id", orderLineUUID);
 				orderLine.put("source", "User");
 				cost.put("currency", "USD"); // TODO: get this from marc or use an env variable
@@ -256,18 +270,57 @@ public class OrderImport {
 				// add a detailsObject if a receiving note or ISBN identifiers are found
                 JSONObject detailsObject = new JSONObject();
                 
+                // get ISBN values in a productIds array and add to detailsObject if not empty 
+                JSONArray productIds = new JSONArray();
+                JSONArray identifiers = marcUtils.buildIdentifiers(record, lookupTable);
+                Iterator identIter = identifiers.iterator();
+                while (identIter.hasNext()) {
+                    JSONObject identifierObj = (JSONObject) identIter.next();
+                    String identifierType = identifierObj.getString("identifierTypeId");
+                    String oldVal = identifierObj.getString("value"); 
+                    JSONObject productId = new JSONObject();
+                    String newVal = StringUtils.substringBefore(oldVal, " ");
+                    String qualifier = StringUtils.substringAfter(oldVal, " ");
+                    productId.put("productId", newVal);
+                    productId.put("productIdType", identifierType);
+                    if (StringUtils.isNotEmpty(qualifier)) {
+                        productId.put("qualifier", qualifier);
+                    }
+                    productIds.put(productId); 
+                    
+                }
+                // TODO: Fix but that causes 422 response if productIds are addet to details in poLine
+                if (productIds.length() > 0) {
+                    logger.debug(productIds.toString(3));
+                    detailsObject.put("productIds", productIds);
+                }
+                
                 // get the "receiving note"
                 String receivingNote =  marcUtils.getReceivingNote(nineEightyOne);
                 if (StringUtils.isNotEmpty(receivingNote)) {
                     detailsObject.put("receivingNote", receivingNote);
                 }
-                // get ISBN values in a productIds array and add to detailsObject if not empty
-                JSONArray productIds = marcUtils.getISBN(record, lookupTable.get("ISBN"));
-                if (productIds.length() > 0) {
-                    detailsObject.put("productIds", productIds);
-                }                
+                
                 if (! detailsObject.isEmpty()) {
                     orderLine.put("details", detailsObject);   
+                }
+                
+                
+                // add contributors
+                JSONArray contribArray = new JSONArray();
+                 
+                JSONArray contributors = marcUtils.buildContributors(record, lookupTable);
+                Iterator contribIter = contributors.iterator();
+                while (contribIter.hasNext()) {
+                    JSONObject contribObj = (JSONObject) contribIter.next();
+                    JSONObject contribCopyObj = new JSONObject();
+                    contribCopyObj.put("contributorNameTypeId", personalNameTypeId);
+                    contribCopyObj.put("contributor", contribObj.get("name"));
+                    contribArray.put(contribCopyObj);
+                }
+                if (contribArray.length() > 0) {
+                    orderLine.put("contributors", contribArray);
+                    logger.debug(contribArray.toString(3));
                 }
 				
 				// get rush value
@@ -289,19 +342,16 @@ public class OrderImport {
 					orderLine.put("requester", requester);
 				}
 				
-				// LOOK UP THE FUND and add info to orderLine
-                //logger.debug("lookup Fund");
-                String fundEndpoint = baseOkapEndpoint + "finance/funds?limit=30&offset=0&query=((code='" + fundCode + "'))";
-                String fundResponse = this.apiService.callApiGet(fundEndpoint, token);
-                JSONObject fundsObject = new JSONObject(fundResponse);
-                String fundId = (String) fundsObject.getJSONArray("funds").getJSONObject(0).get("id");
+				
+				// add fund distribution info
 				JSONArray funds = new JSONArray();
 				JSONObject fundDist = new JSONObject();
 				fundDist.put("distributionType", "percentage");
 				fundDist.put("value", 100);
 				fundDist.put("fundId", fundId);
 				funds.put(fundDist);
-				orderLine.put("fundDistribution", funds);				
+				orderLine.put("fundDistribution", funds);
+				
 
 				orderLine.put("purchaseOrderId", orderUUID.toString());
 				poLines.put(orderLine);
@@ -318,45 +368,46 @@ public class OrderImport {
 			numRec++;
 		} 
 		
-		logger.debug("Here is the PO order number: "+ poNumberObj.get("poNumber"));
-		logger.debug(order.toString(3));
+		logger.info("Here is the PO, order number: "+ poNumberObj.get("poNumber"));
+		logger.info(order.toString(3));
 		
 		//POST THE ORDER AND LINE:
-		String orderResponse = apiService.callApiPostWithUtf8(baseOkapEndpoint + "orders/composite-orders", order, token); 
-		JSONObject approvedOrder = new JSONObject(orderResponse);
+		String orderResponse = apiService.callApiPostWithUtf8(baseOkapEndpoint + "orders/composite-orders", order, token);  
 		 
-		// get approved order
+		// get the updated order
 		
 		//GET THE UPDATED PURCHASE ORDER FROM THE API AND PULL OUT THE ID FOR THE INSTANCE FOLIO CREATED:
 		logger.debug("getUpdatedPurchaseOrder");
 		String updatedPurchaseOrder = apiService.callApiGet(baseOkapEndpoint + "orders/composite-orders/" +orderUUID.toString() ,token); 
 		JSONObject updatedPurchaseOrderJson = new JSONObject(updatedPurchaseOrder);
-		logger.info("updated purchase order...");
-		logger.info(updatedPurchaseOrderJson.toString(3));
+		logger.debug("updated purchase order...");
+		logger.debug(updatedPurchaseOrderJson.toString(3));
 		
-		// read through again.
-        FileInputStream in2 = new FileInputStream(filePath + fileName);
-        MarcReader reader2 = new MarcStreamReader(in2);
+		 
         numRec = 0;         
-        start = System.currentTimeMillis(); 
-        while (reader2.hasNext()) {
-             
+        start = System.currentTimeMillis();
+        Iterator<Object> poLineIterator = updatedPurchaseOrderJson.getJSONArray("compositePoLines").iterator();
+        
+        while (poLineIterator.hasNext()) { 
+            JSONObject poLineObject = (JSONObject) poLineIterator.next();
 			try {
-			    Record record = reader2.next();
+			     
 				JSONObject responseMessage = new JSONObject();
 				responseMessage.put("poNumber", poNumberObj.get("poNumber"));
 				responseMessage.put("poUUID", orderUUID.toString());
 				UUID snapshotId = UUID.randomUUID();
-				UUID recordTableId = UUID.randomUUID();					
+				UUID recordTableId = UUID.randomUUID(); 
 				
-				String poLineUUID = updatedPurchaseOrderJson.getJSONArray("compositePoLines").getJSONObject(numRec).getString("id");
-                String poLineNumber = updatedPurchaseOrderJson.getJSONArray("compositePoLines").getJSONObject(numRec).getString("poLineNumber");
-                String instanceId = updatedPurchaseOrderJson.getJSONArray("compositePoLines").getJSONObject(numRec).getString("instanceId");
-                String title = updatedPurchaseOrderJson.getJSONArray("compositePoLines").getJSONObject(numRec).getString("titleOrPackage");
-                String requester = updatedPurchaseOrderJson.getJSONArray("compositePoLines").getJSONObject(numRec).optString("requester");
-                String internalNote = updatedPurchaseOrderJson.getJSONArray("compositePoLines").getJSONObject(numRec).optString("description");
-                JSONObject polDetails = updatedPurchaseOrderJson.getJSONArray("compositePoLines").getJSONObject(numRec).optJSONObject("details");
-				
+                String poLineUUID = poLineObject.getString("id");
+                String poLineNumber = poLineObject.getString("poLineNumber");
+                String instanceId = poLineObject.getString("instanceId");
+                String title = poLineObject.getString("titleOrPackage");
+                String requester = poLineObject.optString("requester");
+                String internalNote = poLineObject.optString("description");
+                JSONObject polDetails = poLineObject.optJSONObject("details");
+                
+                Record record = recordMap.get(poLineUUID);
+                
 				String receivingNote = null;
 				if (polDetails != null) {
 					receivingNote = polDetails.optString("receivingNote");
@@ -368,7 +419,7 @@ public class OrderImport {
 				responseMessage.put("requester", requester);
 				responseMessage.put("internalNote", internalNote);
 				responseMessage.put("receivingNote", receivingNote);
-				responseMessage.put("vendorCode",vendorCode);
+				responseMessage.put("vendorCode", vendorCode);
 				
 				//GET THE INSTANCE RECORD FOLIO CREATED, SO WE CAN ADD BIB INFO TO IT:
 				logger.debug("get InstanceResponse");
@@ -432,7 +483,9 @@ public class OrderImport {
 				JSONObject sourceRecordStorageObject = new JSONObject();
 				sourceRecordStorageObject.put("recordType", "MARC");
 				sourceRecordStorageObject.put("snapshotId", snapshotId.toString());
-				sourceRecordStorageObject.put("matchedId", instanceId.toString()); // TODO: this should be recordTableId.toString()
+				// TODO: this should be recordTableId.toString()
+				//sourceRecordStorageObject.put("matchedId", instanceId.toString()); 
+				sourceRecordStorageObject.put("matchedId", recordTableId.toString());
 				
 				//LINK THE INSTANCE TO SOURCE RECORD STORAGE
 				JSONObject externalId = new JSONObject();
@@ -456,42 +509,49 @@ public class OrderImport {
 				logger.debug("post sourceRecordStoractObject");
 				String storageResponse = apiService.callApiPostWithUtf8(baseOkapEndpoint + "source-storage/records", sourceRecordStorageObject,token);
 				
-				//ADD IDENTIFIERS AND CONTRIBUTORS TO THE INSTANCE
-				//*AND* CHANGE THE SOURCE TO 'MARC'
-				//SO THE OPTION TO VIEW THE MARC RECORD SHOWS UP 
-				//IN INVENTORY!
-				JSONArray identifiers = buildIdentifiers(record, lookupTable);
-				// copy any ISBN identifiers to the response
-				Iterator identIter = identifiers.iterator();
-                while (identIter.hasNext()) {
-                    JSONObject identifierObj = (JSONObject) identIter.next();
+				// Add Identifiers to the instance
+				JSONArray identifiers = marcUtils.buildIdentifiers(record, lookupTable);
+				Iterator isbnIterator = identifiers.iterator();
+                List<String> isbnList = new ArrayList();
+                while (isbnIterator.hasNext()) {
+                    JSONObject identifierObj = (JSONObject) isbnIterator.next();
                     String identifierType = identifierObj.getString("identifierTypeId");
                     if (identifierType.equals(ISBNId)) {
-                        responseMessage.put("isbn", identifierObj.get("value"));
-                        break;
-                    }
+                        isbnList.add((String) identifierObj.get("value"));
+                   }
                 }
-				JSONArray contributors = buildContributors(record, lookupTable);
+                if (isbnList.size() > 0) {
+                    responseMessage.put("isbn", isbnList.get(0));    
+                }
+                
+                // now get Contributors
+				JSONArray contributors = marcUtils.buildContributors(record, lookupTable);
 				
 				instanceAsJson.put("title", title);
 				instanceAsJson.put("source", "MARC");
 				instanceAsJson.put("instanceTypeId", lookupTable.get("text"));
-				instanceAsJson.put("identifiers", identifiers);
-				instanceAsJson.put("contributors", contributors);
-				instanceAsJson.put("discoverySuppress", false);
-				
+				if (identifiers.length() > 0) {
+                    logger.trace("Adding identifiers...");
+                    instanceAsJson.put("identifiers", identifiers);
+                }
+                if (contributors.length() > 0) {
+                    logger.trace("Adding contributors ...");
+                    instanceAsJson.put("contributors", contributors);
+                }
+				instanceAsJson.put("discoverySuppress", false);				
 				
 				//GET THE HOLDINGS RECORD FOLIO CREATED, SO WE CAN ADD URLs FROM THE 856 IN THE MARC RECORD
 				String holdingResponse = apiService.callApiGet(baseOkapEndpoint + "holdings-storage/holdings?query=(instanceId==" + instanceId + ")", token);
 				JSONObject holdingsAsJson = new JSONObject(holdingResponse);
 				JSONObject holdingRecord = holdingsAsJson.getJSONArray("holdingsRecords").getJSONObject(0);
-				
+							
 				//UPDATE THE INSTANCE RECORD
 				logger.debug("Update Instance Record");
 				//instanceAsJson.put("electronicAccess", eResources);
 				instanceAsJson.put("natureOfContentTermIds", new JSONArray());
 				instanceAsJson.put("precedingTitles", new JSONArray());
 				instanceAsJson.put("succeedingTitles", new JSONArray());
+				logger.debug(instanceAsJson.toString(3));
 				String instanceUpdateResponse = apiService.callApiPut(baseOkapEndpoint + "inventory/instances/" + instanceId,  instanceAsJson, token);
 				
 				logger.debug("Update holdings record");
@@ -501,8 +561,7 @@ public class OrderImport {
 				responseMessage.put("instanceUUID", instanceId);
 				//responseMessage.put("location", locationName +" ("+ lookupTable.get(locationName + "-location") +")");				
 				responseMessages.put(responseMessage);
-				numRec++;
-				
+				numRec++;				
 				
 			} catch(Exception e) {
 				e.printStackTrace();
@@ -516,7 +575,7 @@ public class OrderImport {
 			
 		}
 
-		logger.debug("Number of records: "+ numRec);
+		logger.info("Number of records: "+ numRec);
 		logger.info(responseMessages.toString(3));
 		return responseMessages;
 
@@ -613,136 +672,6 @@ public class OrderImport {
 		    }
 		}
 		return errorMessages;
-		
-	}
-	
-	
-	//TODO - FIX THESE METHODS THAT GATHER DETAILS FROM THE MARC RECORD.
-	//THEY WERE HURRILY CODED
-	//JUST WANTED TO GET SOME DATA IN THE INSTANCE
-	//FROM THE MARC RECORD FOR THIS POC
-	public JSONArray buildContributors(Record record, HashMap<String,String> lookupTable) {
-		JSONArray contributors = new JSONArray();
-		String[] subfields = {"a","b","c","d","f","g","j","k","l","n","p","t","u"};
-		
-		List<DataField> fields = record.getDataFields();
-		Iterator<DataField> fieldsIterator = fields.iterator();
-		while (fieldsIterator.hasNext()) {
-			DataField field = (DataField) fieldsIterator.next();
-			if (field.getTag().equalsIgnoreCase("100") || field.getTag().equalsIgnoreCase("700")) {
-				contributors.put(makeContributor(field,lookupTable, "Personal name", subfields));
-			}
-		}
-		return contributors;
-	}
-	
-	public JSONObject makeContributor( DataField field, HashMap<String,String> lookupTable, String name_type_id, String[] subfieldArray) {
-		List<String> list = Arrays.asList(subfieldArray);
-		JSONObject contributor = new JSONObject();
-		contributor.put("name", "");
-		contributor.put("contributorNameTypeId", lookupTable.get(name_type_id));
-		List<Subfield> subfields =  field.getSubfields();
-		Iterator<Subfield> subfieldIterator = subfields.iterator();
-		String contributorName = "";
-		while (subfieldIterator.hasNext()) {
-			Subfield subfield = (Subfield) subfieldIterator.next();
-			String subfieldAsString = String.valueOf(subfield.getCode());  
-			if (subfield.getCode() == '4') {
-				if (lookupTable.get(subfield.getData()) != null) {
-					contributor.put("contributorTypeId", lookupTable.get(subfield.getData()));
-				}
-				else {
-					contributor.put("contributorTypeId", lookupTable.get("bkp"));
-				}
-			}
-			else if (subfield.getCode() == 'e') {
-				contributor.put("contributorTypeText", subfield.getData());
-			}
-			else if (list.contains(subfieldAsString)) {
-				if (!contributorName.isEmpty()) {
-					contributorName += ", " + subfield.getData();
-				}
-				else {
-					contributorName +=  subfield.getData();
-				}
-			}
-			
-		}
-		contributor.put("name", contributorName);
-		return contributor;
-	}
-	
-   
-   public JSONArray buildIdentifiers(Record record, HashMap<String, String> lookupTable) {
-		JSONArray identifiers = new JSONArray();
-		
-		List<DataField> fields = record.getDataFields();
-		Iterator<DataField> fieldsIterator = fields.iterator();
-		while (fieldsIterator.hasNext()) {
-			DataField field = (DataField) fieldsIterator.next(); 
-			List<Subfield> subfields =  field.getSubfields();
-			Iterator<Subfield> subfieldIterator = subfields.iterator();
-			while (subfieldIterator.hasNext()) {
-				Subfield subfield = (Subfield) subfieldIterator.next();
-				if (field.getTag().equalsIgnoreCase("020")) {
-					if (subfield.getCode() == 'a') {
-						JSONObject identifier = new JSONObject();
-						String fullValue = subfield.getData();
-						if (field.getSubfield('c') != null) fullValue += " "  + field.getSubfieldsAsString("c");
-						if (field.getSubfield('q') != null) fullValue += " " + field.getSubfieldsAsString("q");
-						identifier.put("value",fullValue);
-						
-						identifier.put("identifierTypeId", lookupTable.get("ISBN"));
-						identifiers.put(identifier);
-					}
-					if (subfield.getCode() == 'z') {
-						JSONObject identifier = new JSONObject();
-						String fullValue = subfield.getData();
-						if (field.getSubfield('c') != null) fullValue += " " + field.getSubfieldsAsString("c");
-						if (field.getSubfield('q') != null) fullValue += " " + field.getSubfieldsAsString("q");
-						identifier.put("value", fullValue);
-						identifier.put("identifierTypeId", lookupTable.get("Invalid ISBN"));
-						identifiers.put(identifier);
-					}
-				}
-				if (field.getTag().equalsIgnoreCase("022")) {
-					if (subfield.getCode() == 'a') {
-						JSONObject identifier = new JSONObject();
-						String fullValue = subfield.getData();
-						if (field.getSubfield('c') != null) fullValue += " " + field.getSubfieldsAsString("c");
-						if (field.getSubfield('q') != null) fullValue += " " + field.getSubfieldsAsString("q");
-						identifier.put("value",fullValue);
-						
-						identifier.put("identifierTypeId", lookupTable.get("ISSN"));
-						identifiers.put(identifier);
-					} else if (subfield.getCode() == 'l') {
-						JSONObject identifier = new JSONObject();
-						String fullValue = subfield.getData();
-						if (field.getSubfield('c') != null) fullValue += " " + field.getSubfieldsAsString("c");
-						if (field.getSubfield('q') != null) fullValue += " " + field.getSubfieldsAsString("q");
-						identifier.put("value", fullValue);
-						identifier.put("identifierTypeId", lookupTable.get("Linking ISSN"));
-						identifiers.put(identifier);
-					} else {
-						JSONObject identifier = new JSONObject();
-						String fullValue = "";
-						if (field.getSubfield('z') != null) fullValue += field.getSubfieldsAsString("z");
-						if (field.getSubfield('y') != null) fullValue += " " +  field.getSubfieldsAsString("y");
-						if (field.getSubfield('m') != null) fullValue += " " + field.getSubfieldsAsString("m");
-						if (fullValue != "") {
-							identifier.put("value", fullValue);
-							identifier.put("identifierTypeId", lookupTable.get("Invalid ISSN"));
-							identifiers.put(identifier);
-						}
-					}
-				}
-				
-				
-			}
-			
-		}
-		return identifiers;
-		
 		
 	}
    

--- a/src/main/java/org/olf/folio/order/services/ApiService.java
+++ b/src/main/java/org/olf/folio/order/services/ApiService.java
@@ -55,6 +55,7 @@ public class ApiService {
 
 		if (responseCode > 399) {
 			logger.error("Failed GET");
+			logger.error(responseString);
 			throw new Exception(responseString);
 		}
 		return responseString;
@@ -92,6 +93,7 @@ public class ApiService {
 
 		if (responseCode > 399) {
 			logger.error("Failed POST");
+			logger.error(responseString);
 			throw new Exception(responseString);
 		}
 
@@ -105,11 +107,11 @@ public class ApiService {
 		HttpUriRequest request = RequestBuilder.put()
 				.setUri(url)
 				.setCharset(Charset.defaultCharset())
-				.setEntity(new StringEntity(body.toString(),"UTF8"))
+				.setEntity(new StringEntity(body.toString(), "UTF8"))
 				.setHeader("x-okapi-tenant", this.tenant)
 				.setHeader("x-okapi-token", token)
 				.setHeader("Accept", "application/json")
-				.setHeader("Content-type","application/json")
+				.setHeader("Content-type", "application/json")
 				.build();
 		
 		//TODO
@@ -118,7 +120,7 @@ public class ApiService {
 		//THE OTHER API CALL THAT USES PUT,
 		//WANTS 'APPLICATION/JSON'
 		if (url.contains("orders-storage") || url.contains("holdings-storage")) {
-			request.setHeader("Accept","text/plain");
+			request.setHeader("Accept", "text/plain");
 		}
 		HttpResponse response = client.execute(request);
 		int responseCode = response.getStatusLine().getStatusCode();
@@ -130,6 +132,9 @@ public class ApiService {
 
 		if (responseCode > 399) {
 			logger.error("Failed PUT");
+			logger.error("BODY");
+			logger.error(body.toString(3));
+			logger.error(response);
 			throw new Exception("Response: " + responseCode);
 		}
 		return "ok";

--- a/src/main/java/org/olf/folio/order/util/MarcUtils.java
+++ b/src/main/java/org/olf/folio/order/util/MarcUtils.java
@@ -11,6 +11,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.Record;
+import org.marc4j.marc.Subfield;
 import org.marc4j.marc.VariableField;
 
 public class MarcUtils {
@@ -182,6 +183,39 @@ public class MarcUtils {
 		}
 		return electronicIndicator;
 	}
+	
+	/**
+	 * Get an array of productIds that contain ISBN values
+	 * @param record
+	 * @param isbnType
+	 * @return
+	 */
+	public JSONArray getISBN(Record record, String isbnType) {
+        JSONArray productIds = new JSONArray();
+        DataField df = (DataField) record.getVariableField("020");
+        if (df != null) {
+            List<Subfield> subfields =  df.getSubfields();
+            for (Subfield subfield: subfields) {
+                if (subfield.getCode() == 'a') {
+                    JSONObject productId = new JSONObject();
+                    String fullValue = subfield.getData();
+                    if (df.getSubfield('c') != null) {
+                        fullValue += " "  + df.getSubfieldsAsString("c");
+                    }
+                    if (df.getSubfield('q') != null) {
+                        fullValue += " " + df.getSubfieldsAsString("q");
+                    }
+                    
+                    productId.put("productId",fullValue);
+                    productId.put("productIdType", isbnType);
+                    productIds.put(productId);
+               
+                } 
+            }
+            
+        }
+        return productIds;
+    }
 	
 	public JSONArray getLinks(Record record) {
 		JSONArray eResources = new JSONArray();

--- a/src/main/java/org/olf/folio/order/util/MarcUtils.java
+++ b/src/main/java/org/olf/folio/order/util/MarcUtils.java
@@ -3,6 +3,8 @@ package org.olf.folio.order.util;
  
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
@@ -184,42 +186,7 @@ public class MarcUtils {
 		return electronicIndicator;
 	}
 	
-	/**
-	 * Get an array of productIds that contain ISBN values.
-	 * @param record
-	 * @param isbnType
-	 * @return
-	 */
-	public JSONArray getISBN(Record record, String isbnType) {
-        JSONArray productIds = new JSONArray();
-        DataField df = (DataField) record.getVariableField("020");
-        if (df != null) {
-            List<Subfield> subfields =  df.getSubfields();
-            for (Subfield subfield: subfields) {
-                if (subfield.getCode() == 'a') {
-                    JSONObject productId = new JSONObject();
-                    String fullValue = subfield.getData();
-                    if (df.getSubfield('c') != null) {
-                        fullValue += " "  + df.getSubfieldsAsString("c");
-                    }
-                    if (df.getSubfield('q') != null) {
-                        fullValue += " " + df.getSubfieldsAsString("q");
-                    }
-                    String isbn = StringUtils.substringBefore(fullValue, " ");
-                    String qualifier = StringUtils.substringAfter(fullValue, " ");
-                    productId.put("productId", isbn);
-                    productId.put("productIdType", isbnType);
-                    if (StringUtils.isNotEmpty(qualifier)) {
-                        productId.put("qualifier", qualifier);
-                    }
-                    productIds.put(productId);
-               
-                } 
-            }
-            
-        }
-        return productIds;
-    }
+	
 	
 	public JSONArray getLinks(Record record) {
 		JSONArray eResources = new JSONArray();
@@ -249,6 +216,133 @@ public class MarcUtils {
 		
 	}
 	
+	//TODO - FIX THESE METHODS THAT GATHER DETAILS FROM THE MARC RECORD.
+    //THEY WERE HURRILY CODED
+    //JUST WANTED TO GET SOME DATA IN THE INSTANCE
+    //FROM THE MARC RECORD FOR THIS POC
+    public JSONArray buildContributors(Record record, HashMap<String,String> lookupTable) {
+        JSONArray contributors = new JSONArray();
+        String[] subfields = {"a","b","c","d","f","g","j","k","l","n","p","t","u"};
+        
+        List<DataField> fields = record.getDataFields();
+        Iterator<DataField> fieldsIterator = fields.iterator();
+        while (fieldsIterator.hasNext()) {
+            DataField field = (DataField) fieldsIterator.next();
+            if (field.getTag().equalsIgnoreCase("100") || field.getTag().equalsIgnoreCase("700")) {
+                contributors.put(makeContributor(field,lookupTable, "Personal name", subfields));
+            }
+        }
+        return contributors;
+    }
+    
+    public JSONObject makeContributor( DataField field, HashMap<String,String> lookupTable, String name_type_id, String[] subfieldArray) {
+        List<String> list = Arrays.asList(subfieldArray);
+        JSONObject contributor = new JSONObject();
+        contributor.put("name", "");
+        contributor.put("contributorNameTypeId", lookupTable.get(name_type_id));
+        List<Subfield> subfields =  field.getSubfields();
+        Iterator<Subfield> subfieldIterator = subfields.iterator();
+        String contributorName = "";
+        while (subfieldIterator.hasNext()) {
+            Subfield subfield = (Subfield) subfieldIterator.next();
+            String subfieldAsString = String.valueOf(subfield.getCode());  
+            if (subfield.getCode() == '4') {
+                if (lookupTable.get(subfield.getData()) != null) {
+                    contributor.put("contributorTypeId", lookupTable.get(subfield.getData()));
+                }
+                else {
+                    contributor.put("contributorTypeId", lookupTable.get("bkp"));
+                }
+            }
+            else if (subfield.getCode() == 'e') {
+                contributor.put("contributorTypeText", subfield.getData());
+            }
+            else if (list.contains(subfieldAsString)) {
+                if (!contributorName.isEmpty()) {
+                    contributorName += ", " + subfield.getData();
+                }
+                else {
+                    contributorName +=  subfield.getData();
+                }
+            }
+            
+        }
+        contributor.put("name", contributorName);
+        return contributor;
+    }
+    
+   
+   public JSONArray buildIdentifiers(Record record, HashMap<String, String> lookupTable) {
+        JSONArray identifiers = new JSONArray();
+        
+        List<DataField> fields = record.getDataFields();
+        Iterator<DataField> fieldsIterator = fields.iterator();
+        while (fieldsIterator.hasNext()) {
+            DataField field = (DataField) fieldsIterator.next(); 
+            List<Subfield> subfields =  field.getSubfields();
+            Iterator<Subfield> subfieldIterator = subfields.iterator();
+            while (subfieldIterator.hasNext()) {
+                Subfield subfield = (Subfield) subfieldIterator.next();
+                if (field.getTag().equalsIgnoreCase("020")) {
+                    if (subfield.getCode() == 'a') {
+                        JSONObject identifier = new JSONObject();
+                        String fullValue = subfield.getData();
+                        if (field.getSubfield('c') != null) fullValue += " "  + field.getSubfieldsAsString("c");
+                        if (field.getSubfield('q') != null) fullValue += " " + field.getSubfieldsAsString("q");
+                        identifier.put("value",fullValue);
+                        
+                        identifier.put("identifierTypeId", lookupTable.get("ISBN"));
+                        identifiers.put(identifier);
+                    }
+                    if (subfield.getCode() == 'z') {
+                        JSONObject identifier = new JSONObject();
+                        String fullValue = subfield.getData();
+                        if (field.getSubfield('c') != null) fullValue += " " + field.getSubfieldsAsString("c");
+                        if (field.getSubfield('q') != null) fullValue += " " + field.getSubfieldsAsString("q");
+                        identifier.put("value", fullValue);
+                        identifier.put("identifierTypeId", lookupTable.get("Invalid ISBN"));
+                        identifiers.put(identifier);
+                    }
+                }
+                if (field.getTag().equalsIgnoreCase("022")) {
+                    if (subfield.getCode() == 'a') {
+                        JSONObject identifier = new JSONObject();
+                        String fullValue = subfield.getData();
+                        if (field.getSubfield('c') != null) fullValue += " " + field.getSubfieldsAsString("c");
+                        if (field.getSubfield('q') != null) fullValue += " " + field.getSubfieldsAsString("q");
+                        identifier.put("value",fullValue);
+                        
+                        identifier.put("identifierTypeId", lookupTable.get("ISSN"));
+                        identifiers.put(identifier);
+                    } else if (subfield.getCode() == 'l') {
+                        JSONObject identifier = new JSONObject();
+                        String fullValue = subfield.getData();
+                        if (field.getSubfield('c') != null) fullValue += " " + field.getSubfieldsAsString("c");
+                        if (field.getSubfield('q') != null) fullValue += " " + field.getSubfieldsAsString("q");
+                        identifier.put("value", fullValue);
+                        identifier.put("identifierTypeId", lookupTable.get("Linking ISSN"));
+                        identifiers.put(identifier);
+                    } else {
+                        JSONObject identifier = new JSONObject();
+                        String fullValue = "";
+                        if (field.getSubfield('z') != null) fullValue += field.getSubfieldsAsString("z");
+                        if (field.getSubfield('y') != null) fullValue += " " +  field.getSubfieldsAsString("y");
+                        if (field.getSubfield('m') != null) fullValue += " " + field.getSubfieldsAsString("m");
+                        if (fullValue != "") {
+                            identifier.put("value", fullValue);
+                            identifier.put("identifierTypeId", lookupTable.get("Invalid ISSN"));
+                            identifiers.put(identifier);
+                        }
+                    }
+                }
+                
+                
+            }
+            
+        }
+        return identifiers; 
+    } 
+	
 	public String normalizePrice(String priceStr) {
 	    try {
 	       double f = Double.parseDouble(priceStr);
@@ -256,7 +350,6 @@ public class MarcUtils {
 	    } catch (NumberFormatException e) {
 	        return "0.00";
 	    }
-	}
-	
+	}	
 
 }

--- a/src/main/java/org/olf/folio/order/util/MarcUtils.java
+++ b/src/main/java/org/olf/folio/order/util/MarcUtils.java
@@ -185,7 +185,7 @@ public class MarcUtils {
 	}
 	
 	/**
-	 * Get an array of productIds that contain ISBN values
+	 * Get an array of productIds that contain ISBN values.
 	 * @param record
 	 * @param isbnType
 	 * @return
@@ -205,9 +205,13 @@ public class MarcUtils {
                     if (df.getSubfield('q') != null) {
                         fullValue += " " + df.getSubfieldsAsString("q");
                     }
-                    
-                    productId.put("productId",fullValue);
+                    String isbn = StringUtils.substringBefore(fullValue, " ");
+                    String qualifier = StringUtils.substringAfter(fullValue, " ");
+                    productId.put("productId", isbn);
                     productId.put("productIdType", isbnType);
+                    if (StringUtils.isNotEmpty(qualifier)) {
+                        productId.put("qualifier", qualifier);
+                    }
                     productIds.put(productId);
                
                 } 

--- a/src/main/webapp/WEB-INF/upload-order.jsp
+++ b/src/main/webapp/WEB-INF/upload-order.jsp
@@ -271,7 +271,7 @@ function showname() {
 
 <script id="orderTemplate" type="text/x-handlebars-template">
 {{#if this.0.poUUID}}
-  <p><b>Created Purchase Order Number</b>: <a href="${baseFolioUrl}orders/view/{{this.0.poUUID}}" title="View this PO in FOLIO Orders app" target="_blank">{{this.0.poNumber}}</a></p>
+  <p><b>Created Purchase Order Number</b>: <a href="${baseFolioUrl}orders/view/{{this.0.poUUID}}" title="View this PO in FOLIO Orders app" target="_blank">{{this.0.poNumber}}</a> - {{this.0.vendorCode}}</p>
 {{/if}}
 
 <ul>
@@ -285,6 +285,7 @@ function showname() {
           <dt><a href="${baseFolioUrl}orders/lines/view/{{poLineUUID}}" title="View this PO Line in FOLIO Orders app" target="_blank">{{poLineNumber}}</a></dt>
           <dd><a href="${baseFolioUrl}inventory/view/{{instanceUUID}}" title="View this Instance in FOLIO Inventory app" target="_blank">{{title}}</a></dd>
           <dd class="metadata">{{instanceHrid}}</dd>
+          <dd class="metadata">{{isbn}}</dd>
           <dd class="metadata"><strong>{{requester}}</strong></dd>
           <dd class="metadata">{{{linkify internalNote}}}</dd>
           <dd class="metadata">{{{linkify receivingNote}}}</dd>

--- a/src/test/java/org/olf/folio/order/util/LookupUtilContributorNameTest.java
+++ b/src/test/java/org/olf/folio/order/util/LookupUtilContributorNameTest.java
@@ -30,13 +30,14 @@ public class LookupUtilContributorNameTest extends LookupUtilBaseTest {
 		try { 
 			map = this.getUtil().getReferenceValues(this.getToken());
 			if (debug) {
-				Iterator iter = map.keySet().iterator();
+				//Iterator iter = map.keySet().iterator();
 				
-				while (iter.hasNext()) {
-					String key = (String) iter.next();
-					System.out.println("name: "+ key);
-					System.out.println("id: "+ map.get(key));
-				}
+				//while (iter.hasNext()) {
+				//	String key = (String) iter.next();
+				//	System.out.println("name: "+ key);
+				//	System.out.println("id: "+ map.get(key));
+				//}
+				System.out.println("Personal name: "+ map.get("Personal name"));
 			} else {
 				String testKey = "Personal name";
 				assertNotNull(map);

--- a/src/test/java/org/olf/folio/order/util/LookupUtilIdentifiersTest.java
+++ b/src/test/java/org/olf/folio/order/util/LookupUtilIdentifiersTest.java
@@ -23,18 +23,21 @@ public class LookupUtilIdentifiersTest extends LookupUtilBaseTest {
 	 
 	@Test
 	public void getIdentifiersTest() { 
-		this.getUtil().setEndPoint("identifier-types", "1000");
+		this.getUtil().setEndPoint("identifier-types", "10000");
 		Map<String,String> map = new HashMap<String, String>();
 		try { 
 			map = this.getUtil().getReferenceValues(this.getToken());
 			if (debug) {
-				Iterator iter = map.keySet().iterator();
+				//Iterator iter = map.keySet().iterator();
 				
-				while (iter.hasNext()) {
-					String key = (String) iter.next();
-					System.out.println("name: "+ key);
-					System.out.println("id: "+ map.get(key));
-				}
+				//while (iter.hasNext()) {
+				//	String key = (String) iter.next();
+				//	System.out.println("name: "+ key);
+				//	System.out.println("id: "+ map.get(key));
+				//}
+				
+				System.out.println(("ISBN: "+ map.get("ISBN")));
+				System.out.println("Invalid ISBN: "+ map.get("Invalid ISBN"));
 			} else {
 				String testKey = "ISBN";
 				assertNotNull(map);

--- a/src/test/java/org/olf/folio/order/util/MarcUtilsBaseTest.java
+++ b/src/test/java/org/olf/folio/order/util/MarcUtilsBaseTest.java
@@ -33,6 +33,7 @@ public class MarcUtilsBaseTest {
     protected String bksFO;
 
     MarcUtils marcUtils = new MarcUtils();
+    List<String> fnames = new ArrayList<String>();
 
     public MarcUtilsBaseTest() {
         init();
@@ -43,8 +44,18 @@ public class MarcUtilsBaseTest {
         this.coutts = this.buildDir + "/marc-test-files/CouttsUKFO.1.mrc";
         this.requestors = this.buildDir + "/marc-test-files/requesters_5-records_2021-03-11.mrc";
         this.singleharrass = this.buildDir + "/marc-test-files/singleharrass.mrc";
-        this.harrassowitz = this.buildDir + "/marc-test-files/harrasowitz_9-records_2021-03-10.mrc";
-        this.bksFO = this.buildDir + "/marc-test-files/w.j.bksFO.mrc";
+        this.harrassowitz = this.buildDir + "/marc-test-files/harrassowitz_9-records_2021-03-10.mrc";
+        this.bksFO = this.buildDir + "/marc-test-files/w.j.bksFO.1.mrc";
+        
+        fnames.add(this.harrass);
+        fnames.add(this.casalini);
+        fnames.add(this.physical);
+        fnames.add(this.amazonFO);
+        fnames.add(this.coutts);
+        fnames.add(this.requestors);
+        fnames.add(this.singleharrass);
+        fnames.add(this.harrassowitz);
+        fnames.add(this.bksFO);
     }
 
     public List<Record> getRecords(String fname) throws Exception {
@@ -66,7 +77,6 @@ public class MarcUtilsBaseTest {
         String use_env = System.getenv("USE_SYSTEM_ENV");
         if (StringUtils.isNotEmpty(use_env) && StringUtils.equals(use_env, "true")) {
             config.setProperty("buildDir", System.getenv("buildDir"));
-
         } else {
             try {
                 props.load(ClassLoader.getSystemResourceAsStream("application.properties"));

--- a/src/test/java/org/olf/folio/order/util/MarcUtilsBuildContributorsTest.java
+++ b/src/test/java/org/olf/folio/order/util/MarcUtilsBuildContributorsTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -15,15 +18,18 @@ import org.marc4j.marc.Record;
  * @author jaf30
  *
  */
-public class MarcUtilsIsbnTest extends MarcUtilsBaseTest { 
+public class MarcUtilsBuildContributorsTest extends MarcUtilsBaseTest { 
     
     boolean debug = false;
-
+    String personalNameTypeId = "2b94c631-fca9-4892-a730-03ee529ffe2a";
+    
     @Test
-    public void testGetIsbn() {
+    public void testBuildContributors() {
+        HashMap<String, String> lookupTable = new HashMap<String, String>();
+        //lookupTable.put("bkp", "8261054f-be78-422d-bd51-4ed9f33c3422");
          
         List<String> myFnames = new ArrayList<String>();
-        myFnames.add(this.harrassowitz);
+        myFnames.add(this.amazonFO);
         
         try {
             for (String fname : myFnames) {
@@ -31,13 +37,13 @@ public class MarcUtilsIsbnTest extends MarcUtilsBaseTest {
                 List<Record> records = getRecords(fname);
                 for (Record record : records) {
                     JSONObject jsonObj = new JSONObject();
-                    JSONArray productIds = marcUtils.getISBN(record, "8261054f-be78-422d-bd51-4ed9f33c3422");
-                    jsonObj.put("productIds", productIds);
+                    JSONArray contributors = marcUtils.buildContributors(record, lookupTable);
+                    jsonObj.put("contributors", contributors);
                     if (debug) {
                         System.out.println(jsonObj.toString(3));
                     } else {
-                        assertNotNull(productIds);
-                        assertTrue(productIds.length() > 0);
+                        assertNotNull(contributors);
+                        assertTrue(contributors.length() > 0);
                     }
                 } 
             }

--- a/src/test/java/org/olf/folio/order/util/MarcUtilsBuildIdentifiersTest.java
+++ b/src/test/java/org/olf/folio/order/util/MarcUtilsBuildIdentifiersTest.java
@@ -1,0 +1,58 @@
+package org.olf.folio.order.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.marc4j.marc.Record;
+
+/**
+ * @author jaf30
+ *
+ */
+public class MarcUtilsBuildIdentifiersTest extends MarcUtilsBaseTest { 
+    
+    boolean debug = false;
+
+    @Test
+    public void testBuildIdentifiers() {
+        HashMap<String, String> lookupTable = new HashMap<String, String>();
+        lookupTable.put("ISBN", "8261054f-be78-422d-bd51-4ed9f33c3422");
+        lookupTable.put("Invalid ISBN", "fcca2643-406a-482a-b760-7a7f8aec640e");
+        lookupTable.put("ISSN", "913300b2-03ed-469a-8179-c1092c991227");
+        lookupTable.put("Invalid ISSN", "27fd35a6-b8f6-41f2-aa0e-9c663ceb250c");
+        lookupTable.put("Linking ISSN", "5860f255-a27f-4916-a830-262aa900a6b9");
+        
+        List<String> myFnames = new ArrayList<String>();
+        myFnames.add(this.singleharrass);
+        
+        try {
+            for (String fname : myFnames) {
+                // System.out.println(fname);
+                List<Record> records = getRecords(fname);
+                for (Record record : records) {
+                    JSONObject jsonObj = new JSONObject();
+                    JSONArray identifiers = marcUtils.buildIdentifiers(record, lookupTable);
+                    jsonObj.put("identifiers", identifiers);
+                    if (debug) {
+                        System.out.println(jsonObj.toString(3));
+                    } else {
+                        assertNotNull(identifiers);
+                        assertTrue(identifiers.length() > 0);
+                    }
+                } 
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+    } 
+}

--- a/src/test/java/org/olf/folio/order/util/MarcUtilsElectronicTest.java
+++ b/src/test/java/org/olf/folio/order/util/MarcUtilsElectronicTest.java
@@ -10,7 +10,7 @@ import org.marc4j.marc.Record;
 
 public class MarcUtilsElectronicTest extends MarcUtilsBaseTest { 
 	 
-    boolean debug = true;
+    boolean debug = false;
     
 	@Test
 	public void testGetElectronic() {

--- a/src/test/java/org/olf/folio/order/util/MarcUtilsIsbnTest.java
+++ b/src/test/java/org/olf/folio/order/util/MarcUtilsIsbnTest.java
@@ -1,0 +1,49 @@
+package org.olf.folio.order.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.marc4j.marc.Record;
+
+/**
+ * @author jaf30
+ *
+ */
+public class MarcUtilsIsbnTest extends MarcUtilsBaseTest { 
+    
+    boolean debug = false;
+
+    @Test
+    public void testGetIsbn() {
+         
+        List<String> myFnames = new ArrayList<String>();
+        myFnames.add(this.harrass);
+        
+        try {
+            for (String fname : myFnames) {
+                // System.out.println(fname);
+                List<Record> records = getRecords(fname);
+                for (Record record : records) {
+                    JSONObject jsonObj = new JSONObject();
+                    JSONArray productIds = marcUtils.getISBN(record, "8261054f-be78-422d-bd51-4ed9f33c3422");
+                    jsonObj.put("productIds", productIds);
+                    if (debug) {
+                        System.out.println(jsonObj.toString(3));
+                    } else {
+                        assertNotNull(productIds);
+                        assertTrue(productIds.length() > 0);
+                    }
+                } 
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+    } 
+}

--- a/src/test/java/org/olf/folio/order/util/MarcUtilsIsbnTest.java
+++ b/src/test/java/org/olf/folio/order/util/MarcUtilsIsbnTest.java
@@ -23,7 +23,7 @@ public class MarcUtilsIsbnTest extends MarcUtilsBaseTest {
     public void testGetIsbn() {
          
         List<String> myFnames = new ArrayList<String>();
-        myFnames.add(this.harrass);
+        myFnames.add(this.harrassowitz);
         
         try {
             for (String fname : myFnames) {

--- a/src/test/java/org/olf/folio/order/util/MarcUtilsPriceTest.java
+++ b/src/test/java/org/olf/folio/order/util/MarcUtilsPriceTest.java
@@ -17,7 +17,7 @@ import org.marc4j.marc.Record;
  */
 public class MarcUtilsPriceTest extends MarcUtilsBaseTest { 
     
-    boolean debug = true;
+    boolean debug = false;
 
     /**
      * 

--- a/src/test/java/org/olf/folio/order/util/MarcUtilsVendorIdTest.java
+++ b/src/test/java/org/olf/folio/order/util/MarcUtilsVendorIdTest.java
@@ -16,7 +16,7 @@ import org.marc4j.marc.Record;
  *
  */
 public class MarcUtilsVendorIdTest extends MarcUtilsBaseTest { 
-    boolean debug = true; 
+    boolean debug = false; 
 
     @Test
     public void testGetVendorId() {


### PR DESCRIPTION
This PR uses to buildIdentifiers and buildContributors methods to obtain identifiers and contributors to be added to the po line.  It has to rename element names (e.g. change "name" to "contributor") in order to produce valid JSON for the order line.  It also adds the vendorCode and the first ISBN number from the identifiers list to the response.

In order to facilitate testing of this functionality, the buildIdentifiers and buildContributors methods have been moved to the MarcUtils class and junit tests have been added.

> * resolves #48
> * resolves #49
> * resolves #52
> * resolves #57