### PR TITLE
Support vendor (org) code with forward slashes via urlencode

### DIFF
--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -5,7 +5,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream; 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -198,12 +201,22 @@ public class OrderImport {
 			    String locationName = marcUtils.getLocation(nineFiveTwo);
 			    
 			     
-			    //LOOK UP VENDOR
-			    //logger.debug("lookupVendor");
-				String organizationEndpoint = baseOkapEndpoint + "/organizations-storage/organizations?limit=30&offset=0&query=((code='" + vendorCode + "'))";
-				String orgLookupResponse = this.apiService.callApiGet(organizationEndpoint,  token);
-				JSONObject orgObject = new JSONObject(orgLookupResponse);
-				String vendorId = (String) orgObject.getJSONArray("organizations").getJSONObject(0).get("id");
+				// LOOK UP THE ORGANIZATION (vendor) again!
+				// TODO: Refactor validateRequiredValues() to store org & fund IDs and avoid redundant HTTP requests
+				//logger.debug("lookupVendor");
+				try {
+					// URL encode organization code to avoid cql parse error on forward slash
+					String encodedOrgCode = URLEncoder.encode("\"" + vendorCode + "\"", StandardCharsets.UTF_8.name());
+
+					String organizationEndpoint = baseOkapEndpoint
+							+ "organizations-storage/organizations?query=(code=" + encodedOrgCode + ")";
+					String orgLookupResponse = apiService.callApiGet(organizationEndpoint, token);
+					JSONObject orgObject = new JSONObject(orgLookupResponse);
+					String vendorId = (String) orgObject.getJSONArray("organizations").getJSONObject(0).get("id");
+					order.put("vendor", vendorId);				
+				} catch (UnsupportedEncodingException e) {
+					logger.error(e.getMessage());
+				}
 				
 				//LOOK UP THE FUND
 				//logger.debug("lookup Fund");
@@ -214,7 +227,6 @@ public class OrderImport {
 				
 				// CREATING THE PURCHASE ORDER				
 				
-				order.put("vendor", vendorId);				
 				
 				// POST ORDER LINE
 				//FOLIO WILL CREATE THE INSTANCE, HOLDINGS, ITEM (IF PHYSICAL ITEM)
@@ -735,19 +747,30 @@ public class OrderImport {
 	 */
 	public JSONObject validateOrganization(String orgCode, String title,  String token, String baseOkapiEndpoint ) throws IOException, InterruptedException, Exception {
 		JSONObject errorMessage = new JSONObject();
-	    //LOOK UP THE ORGANIZATION
-	    String organizationEndpoint = baseOkapiEndpoint + "organizations-storage/organizations?limit=30&offset=0&query=((code='" + orgCode + "'))";
-	    String orgLookupResponse = apiService.callApiGet(organizationEndpoint,  token);
-		JSONObject orgObject = new JSONObject(orgLookupResponse);
-		//---------->VALIDATION: MAKE SURE THE ORGANIZATION CODE EXISTS
-		if (orgObject.getJSONArray("organizations").length() < 1) {
-			logger.error(orgObject.toString(3));
-			errorMessage.put("error", "Organization code in file (" + orgCode + ") does not exist in FOLIO");
-			errorMessage.put("title", title);
+
+		try {
+			// URL encode organization code to avoid cql parse error on forward slash
+			String encodedOrgCode = URLEncoder.encode("\"" + orgCode + "\"", StandardCharsets.UTF_8.name());
+
+			//LOOK UP THE ORGANIZATION
+			String organizationEndpoint = baseOkapiEndpoint + "organizations-storage/organizations?query=(code=" + encodedOrgCode + ")";
+			String orgLookupResponse = apiService.callApiGet(organizationEndpoint, token);
+			JSONObject orgObject = new JSONObject(orgLookupResponse);
+			//---------->VALIDATION: MAKE SURE THE ORGANIZATION CODE EXISTS
+			if (orgObject.getJSONArray("organizations").length() < 1) {
+				logger.error(orgObject.toString(3));
+				errorMessage.put("error", "Organization code in file (" + orgCode + ") does not exist in FOLIO");
+				errorMessage.put("title", title);
+				errorMessage.put("PONumber", "~error~");
+				return errorMessage;
+			}
+			return null;
+		} catch (UnsupportedEncodingException e) {
+			logger.error(e.getMessage());
+			errorMessage.put("error", "Unable to URL encoode organization code " + orgCode);
 			errorMessage.put("PONumber", "~error~");
 			return errorMessage;
 		}
-		return null;
 	}
 	
 	/**

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -207,9 +207,11 @@ public class OrderImport {
 				try {
 					// URL encode organization code to avoid cql parse error on forward slash
 					String encodedOrgCode = URLEncoder.encode("\"" + vendorCode + "\"", StandardCharsets.UTF_8.name());
+					logger.debug("encodedOrgCode: " + encodedOrgCode);
 
 					String organizationEndpoint = baseOkapEndpoint
 							+ "organizations-storage/organizations?query=(code=" + encodedOrgCode + ")";
+					logger.debug("organizationEndpoint: " + organizationEndpoint);
 					String orgLookupResponse = apiService.callApiGet(organizationEndpoint, token);
 					JSONObject orgObject = new JSONObject(orgLookupResponse);
 					String vendorId = (String) orgObject.getJSONArray("organizations").getJSONObject(0).get("id");
@@ -751,9 +753,11 @@ public class OrderImport {
 		try {
 			// URL encode organization code to avoid cql parse error on forward slash
 			String encodedOrgCode = URLEncoder.encode("\"" + orgCode + "\"", StandardCharsets.UTF_8.name());
+			logger.debug("encodedOrgCode: " + encodedOrgCode);
 
 			//LOOK UP THE ORGANIZATION
 			String organizationEndpoint = baseOkapiEndpoint + "organizations-storage/organizations?query=(code=" + encodedOrgCode + ")";
+			logger.debug("organizationEndpoint: " + organizationEndpoint);
 			String orgLookupResponse = apiService.callApiGet(organizationEndpoint, token);
 			JSONObject orgObject = new JSONObject(orgLookupResponse);
 			//---------->VALIDATION: MAKE SURE THE ORGANIZATION CODE EXISTS

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -60,6 +60,7 @@ public class OrderImport {
 		JSONArray errorMessages = new JSONArray();
 		
 		//COLLECT VALUES FROM THE CONFIGURATION FILE
+		// TODO: Fix this typo everywhere... Should be baseOkapiEndpoint
 		String baseOkapEndpoint = (String) getMyContext().getAttribute("baseOkapEndpoint");
 		String apiUsername = (String) getMyContext().getAttribute("okapi_username");
 		String apiPassword = (String) getMyContext().getAttribute("okapi_password");

--- a/src/main/java/org/olf/folio/order/services/ApiService.java
+++ b/src/main/java/org/olf/folio/order/services/ApiService.java
@@ -35,6 +35,7 @@ public class ApiService {
 	
 	public String callApiGet(String url, String token) throws Exception, IOException, InterruptedException {
 		CloseableHttpClient client = HttpClients.custom().build();
+    logger.debug("url from ApiService: " + url);
 		HttpUriRequest request = RequestBuilder.get()
 				.setUri(url)
 				.setHeader("x-okapi-tenant", this.tenant)

--- a/src/test/java/org/olf/folio/order/services/GetOrganizationsTest.java
+++ b/src/test/java/org/olf/folio/order/services/GetOrganizationsTest.java
@@ -1,5 +1,8 @@
 package org.olf.folio.order.services;
- 
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Ignore; 
@@ -29,7 +32,7 @@ public class GetOrganizationsTest extends ApiBaseTest {
 	@Test
 	public void testGetAllOrganizations() {
 		 
-		String organizationEndpoint = getBaseOkapEndpoint() + "organizations-storage/organizations?limit=3";
+		String organizationEndpoint = getBaseOkapEndpoint() + "organizations-storage/organizations";
 		try {
 			String orgLookupResponse = getApiService().callApiGet(organizationEndpoint,  getToken());
 			JSONObject orgObject = new JSONObject(orgLookupResponse);
@@ -44,23 +47,30 @@ public class GetOrganizationsTest extends ApiBaseTest {
 	}
 	
 	@Test
-	public void testGetOrganization() { 
-		String vendorCode = "AMAZON";
-		String organizationEndpoint = getBaseOkapEndpoint() + "organizations-storage/organizations?limit=1&offset=0&query=((code='" + vendorCode + "'))";
+	public void testGetOrganization() {
+		String orgCode = "HARRASS/E";
+
 		try {
-			String orgLookupResponse = getApiService().callApiGet(organizationEndpoint,  getToken());
-		    JSONObject orgObject = new JSONObject(orgLookupResponse);
-		    JSONArray jsonArray =  orgObject.getJSONArray("organizations");
-			assertNotNull(jsonArray);
-			String vendorId = (String) jsonArray.getJSONObject(0).get("id");
-			assertTrue(StringUtils.length(vendorId) > 0); 
-			UUID uuid = UUID.fromString(vendorId);
-			//System.out.println("vendorId: "+ vendorId);
-		} catch (IllegalArgumentException e) {
-			fail("vendorID was not a valid UUID");
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			fail(e.getMessage());
+			String encodedOrgCode = URLEncoder.encode("\"" + orgCode + "\"", StandardCharsets.UTF_8.name());
+
+			String organizationEndpoint = getBaseOkapEndpoint() + "organizations-storage/organizations?query=(code=" + encodedOrgCode + ")";
+			try {
+				String orgLookupResponse = getApiService().callApiGet(organizationEndpoint,  getToken());
+					JSONObject orgObject = new JSONObject(orgLookupResponse);
+					JSONArray jsonArray =  orgObject.getJSONArray("organizations");
+				assertNotNull(jsonArray);
+				String vendorId = (String) jsonArray.getJSONObject(0).get("id");
+				assertTrue(StringUtils.length(vendorId) > 0); 
+				UUID uuid = UUID.fromString(vendorId);
+				//System.out.println("vendorId: "+ vendorId);
+			} catch (IllegalArgumentException e) {
+				fail("vendorID was not a valid UUID");
+			} catch (Exception e) {
+				// TODO Auto-generated catch block
+				fail(e.getMessage());
+			}
+		} catch (UnsupportedEncodingException e) {;
+			fail("Unable to URL encoode organization code " + orgCode);
 		}
 	}
 	


### PR DESCRIPTION
Forward slash is a [special character in CQL](https://www.loc.gov/standards/sru/cql/spec.html), so urlencode to avoid `org.folio.cql2pgjson.exception.QueryValidationException` and support Cornell LTS' heavy use of organization (vendor) codes with forward slashes.

We do plan to consolidate the organizations and eliminate codes with forward slashes but this will not be ready for go-live.

Also note that the FOLIO Organizations app (ui-organizations) does not urlencode the organization code in the edit form, and this does nothing to address that bug. In oother words, we still will be unable to edit organizations via the UI which have codes that contain forward slashes.

One final note. The validateRequiredValues() is ripe for refactoring so we can avoid redundant HTTP requests. See TODO.