### PR TITLE
Switching gears: double down on mod-copycat

### DIFF
--- a/src/main/java/org/olf/folio/order/Constants.java
+++ b/src/main/java/org/olf/folio/order/Constants.java
@@ -8,6 +8,7 @@ package org.olf.folio.order;
  */
 public class Constants {
     public static final String BILLINGMAP = "billingMap";
-    public static final String COPYCAT_OCLC_PROFILE = "f26df83c-aa25-40b6-876e-96852c3d4fd4";
+    public static final String COPYCAT_DEFAULT_PROFILE = "4c41105d-a3cc-4f2a-8106-aeee2d30ffd0";
+    public static final String COPYCAT_SHELFREADY_PROFILE = "87592fe9-5b0e-43d2-a0da-13a76e6d0262";
     public static final String LOOKUP_TABLE = "lookupTable";
 }

--- a/src/main/java/org/olf/folio/order/MarcToJson.java
+++ b/src/main/java/org/olf/folio/order/MarcToJson.java
@@ -368,7 +368,7 @@ public class MarcToJson {
                     logger.debug("encodedOrgCode: " + encodedOrgCode);
 
                     String organizationEndpoint = this.getEndpoint()
-                            + "organizations-storage/organizations?query=(code=" + encodedOrgCode + ")";
+                            + "organizations-storage/organizations?query=(code==" + encodedOrgCode + ")";
                     logger.debug("organizationEndpoint: " + organizationEndpoint);
                     String orgLookupResponse = apiService.callApiGet(organizationEndpoint, token);
                     JSONObject orgObject = new JSONObject(orgLookupResponse);

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -197,7 +197,7 @@ public class OrderImport {
 					logger.debug("encodedOrgCode: " + encodedOrgCode);
 
 					String organizationEndpoint = baseOkapEndpoint
-							+ "organizations-storage/organizations?query=(code=" + encodedOrgCode + ")";
+							+ "organizations-storage/organizations?query=(code==" + encodedOrgCode + ")";
 					logger.debug("organizationEndpoint: " + organizationEndpoint);
 					String orgLookupResponse = apiService.callApiGet(organizationEndpoint, token);
 					JSONObject orgObject = new JSONObject(orgLookupResponse);

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -226,7 +226,8 @@ public class OrderImport {
 				
 				// all items are assumed to be physical
 				JSONObject physical = new JSONObject();
-				physical.put("createInventory", "Instance, Holding, Item");
+				// Holding and Item will be created afterwards via mod-copycat)
+				physical.put("createInventory", "Instance");
 				physical.put("materialType", lookupTable.get(materialTypeName));
 				orderLine.put("physical", physical);
 				orderLine.put("orderFormat", "Physical Resource");
@@ -465,78 +466,27 @@ public class OrderImport {
 				String hrid = instanceAsJson.getString("hrid");
                 responseMessage.put("instanceHrid", hrid);
                 responseMessage.put("instanceUUID", instanceId);
-                
-                // get barcode from 976 field, if it exists, add it to the inventory item
-                // TOSO: determine how this will be added to inventory. just grab the value for now
-                DataField nineSevenSix = (DataField) record.getVariableField("976");
-                String barcode = marcUtils.getBarcode(nineSevenSix);
-                if (StringUtils.isNotEmpty(barcode)) {
-                    logger.debug("get holdings for instanceId: "+ instanceId);
-                    String holdingsResponse = apiService.callApiGet(baseOkapEndpoint + "holdings-storage/holdings?query=(instanceId==" + instanceId + ")", token);
-                    JSONObject holdingsObject = new JSONObject(holdingsResponse);
-                    logger.debug(holdingsObject.toString(3));
-                    JSONObject holdingsAsJson = new JSONObject(holdingsResponse);
-                    
-                    // get holdings array
-                    JSONArray holdingsArray = holdingsAsJson.getJSONArray("holdingsRecords");
-                    logger.debug("holdingsArray size: "+ holdingsArray.length());
-                    Iterator  holdingsIter = holdingsArray.iterator();
-                    while (holdingsIter.hasNext() ) {
-                        JSONObject holdingsRecord = (JSONObject) holdingsIter.next();
-                        logger.debug("holdings record");
-                        logger.debug(holdingsRecord.toString(3));
-                        String holdingsId = holdingsRecord.getString("id"); 
-                         
-                        logger.debug("get inventory items with holdingsId: "+ holdingsId);
-                        String queryString =  "holdingsRecordId==" +holdingsId+ " not barcode=\"\"";
-                        String encodedQS = URLEncoder.encode(queryString, StandardCharsets.UTF_8.name());
-                        String itemsEndpoint = baseOkapEndpoint + "inventory/items?query=(" + encodedQS + ")";
-                        String itemsResponse = apiService.callApiGet(itemsEndpoint, token);
-                         
-                        JSONObject itemsObject = new JSONObject(itemsResponse);
-                        logger.debug(itemsObject.toString(3));
-                        
-                        JSONArray itemsArray = itemsObject.getJSONArray("items");
-                        logger.info("items Array size: "+ itemsArray.length());
-                        Iterator itemsIter = itemsArray.iterator();
-                        while (itemsIter.hasNext()) {
-                            JSONObject itemRecord = (JSONObject) itemsIter.next();
-                            itemRecord.put("barcode", barcode);
-                            String itemId = itemRecord.getString("id");
-                            logger.debug("item record: "+ itemId);
-                            logger.debug(itemRecord.toString(3));
-                            // PUT the item
-                            if (StringUtils.isNotEmpty(itemId)) {
-                                logger.info("adding barcode: "+ barcode + " to inventory item "+ itemId);
-                                String itemPutResponse = new String();
-                                try {
-                                    itemPutResponse = apiService.callApiPut(baseOkapEndpoint + "inventory/items/" + itemId,  itemRecord, token);
-                                } catch (Exception ex) {
-                                    logger.error(ex.getMessage());
-                                    JSONObject errorMessage = new JSONObject();
-                                    errorMessage.put("error", ex.getMessage());
-                                    errorMessage.put("PONumber", poNumberObj.get("poNumber"));
-                                    errorMessages.put(errorMessage);
-                                    return errorMessages;    
-                                }
-                                break;
-                            }
-                        }
-                       
-                    }  
-                }
-				// Transform the MARC record into JSON
+
+                // Transform the MARC record into JSON
                 String marcJsonString = marcUtils.recordToMarcJson(record);
                 logger.debug("MARC-JSON " + marcJsonString);
                 JSONObject marcJsonObject = new JSONObject();
                 marcJsonObject.put("json", marcJsonString);
-				
-                //JSON body for POST to mod-copycat for overlay/update of Inventory Instance created by mod-orders
+
+                // JSON body for POST to mod-copycat
+                // -- for overlay/update of Inventory Instance created by mod-orders
+                // -- and creation of Inventory Holding & Inventory Item
                 JSONObject copycatImportObject = new JSONObject();
                 copycatImportObject.put("internalIdentifier", instanceId);
-                // Use constant for mod-copycat's reference data OCLC profile UUID; avoid another HTTP request
-                copycatImportObject.put("profileId", Constants.COPYCAT_OCLC_PROFILE);
+                copycatImportObject.put("profileId", Constants.COPYCAT_DEFAULT_PROFILE);
                 copycatImportObject.put("record", marcJsonObject);
+                
+                // get barcode from 976$p, if it exists, switch to shelf-ready mod-copycat profile
+                DataField nineSevenSix = (DataField) record.getVariableField("976");
+                String barcode = marcUtils.getBarcode(nineSevenSix);
+                if (StringUtils.isNotEmpty(barcode)) {
+                    copycatImportObject.put("profileId", Constants.COPYCAT_SHELFREADY_PROFILE);
+                }
 
 				// Overlay/Update Inventory Instance via mod-copycat
 				logger.debug("post copycatImportObject");

--- a/src/test/java/org/olf/folio/order/services/GetOrganizationsTest.java
+++ b/src/test/java/org/olf/folio/order/services/GetOrganizationsTest.java
@@ -53,7 +53,7 @@ public class GetOrganizationsTest extends ApiBaseTest {
 		try {
 			String encodedOrgCode = URLEncoder.encode("\"" + orgCode + "\"", StandardCharsets.UTF_8.name());
 
-			String organizationEndpoint = getBaseOkapEndpoint() + "organizations-storage/organizations?query=(code=" + encodedOrgCode + ")";
+			String organizationEndpoint = getBaseOkapEndpoint() + "organizations-storage/organizations?query=(code==" + encodedOrgCode + ")";
 			try {
 				String orgLookupResponse = getApiService().callApiGet(organizationEndpoint,  getToken());
 					JSONObject orgObject = new JSONObject(orgLookupResponse);


### PR DESCRIPTION
## BEFORE
1. mod-orders created all Inventory pieces (via mod-inventory)
   * Instance
   * Holding
   * Item
2. mod-copycat was used to overlay the existing Instance and create SRS
   record (swich the Instance to source = MARC)
3. followup PUT to inventory/items to add barcode for shelf-ready orders

## AFTER
1. mod-orders creates Inventory Instance only (via mod-inventory)
2. mod-copycat takes it from there
   * overlays existing Instance and creates SRS record
   * creates Holding & Item based on selected Data Import Job Profile***

*** DI Job Profile is actually determined via Z39.50 Target Profile
(Settings > Inventory > Integrations > Z39.50 target profiles). Clear as
mud...

mod-copycat allows for single record creation or update by leveraging
mod-data-import behind the scenes. The connection between the two
modules is mediated via mod-inventory's Z39.50 integration config.
Thankfully, mod-copycat authors had the insight to provide a raw record
mode [1] which essentially bypasses the Z39.50 integration piece and
allows the MARC to be delivered directly via the request body.

Two new Z39.50 target profiles were created:
* Order import
* Order import: shelf-ready

In coordination with two new DI Job Profiles (along with highlights
courtesy of their respective match/action/mapping profiles):
* Lehigh App – default
  - sets Holding Call Number to "On order"
* Lehigh App – shelf-ready
  - adds Item barcode from `976$p`
  - sets Item status to "Available"

🙌🏼 @starsplatter & @natalyapik

> Picking up where #66 left off

[1] https://github.com/folio-org/mod-copycat#introduction