### PR TITLE
Include fund code per POL for composite order

### DIFF
--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -354,9 +354,10 @@ public class OrderImport {
 				// add fund distribution info
 				JSONArray funds = new JSONArray();
 				JSONObject fundDist = new JSONObject();
+				fundDist.put("code", fundCode);
+				fundDist.put("fundId", fundId);
 				fundDist.put("distributionType", "percentage");
 				fundDist.put("value", 100);
-				fundDist.put("fundId", fundId);
 				funds.put(fundDist);
 				orderLine.put("fundDistribution", funds);
 				


### PR DESCRIPTION
Although the frontend (ui-orders) will still function properly and render the linked fund from the POL, the fund code will not be included in the CSV export unless it's added to the POL directly.

See #73 for more details/background.

> Resolves #73