### PR TITLE
Ensure location lookup is case insensitive

### DIFF
--- a/src/main/java/org/olf/folio/order/util/MarcUtils.java
+++ b/src/main/java/org/olf/folio/order/util/MarcUtils.java
@@ -132,7 +132,7 @@ public class MarcUtils {
 	    } else {
 	        location = "olin";
 	    }
-	    return location;
+	    return location.toLowerCase();
 	}
 	
 	public String getRequester(DataField nineEightyOne ) {


### PR DESCRIPTION
These lookup tables need to go (or be refactored)...

A MARC record with `952$b` == `ASIA` was causing the lookup to fail
because the location lookup table stores location codes which are all
lowercase.