### PR TITLE
Set quantity (980$g) for cost & locations

### DIFF
--- a/src/main/java/org/olf/folio/order/MarcToJson.java
+++ b/src/main/java/org/olf/folio/order/MarcToJson.java
@@ -402,7 +402,7 @@ public class MarcToJson {
                 orderLine.put("physical", physical);
                 orderLine.put("orderFormat", "Physical Resource");
                 cost.put("listUnitPrice", price);
-                cost.put("quantityPhysical", 1);
+                cost.put("quantityPhysical", quantityNo);
                 location.put("quantityPhysical", quantityNo);
                 location.put("locationId", lookupTable.get(locationName + "-location"));
                 locations.put(location);

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -248,7 +248,7 @@ public class OrderImport {
 				orderLine.put("physical", physical);
 				orderLine.put("orderFormat", "Physical Resource");
 				cost.put("listUnitPrice", price);
-				cost.put("quantityPhysical", 1);
+				cost.put("quantityPhysical", quantityNo);
 				location.put("quantityPhysical", quantityNo);
 				location.put("locationId", lookupTable.get(locationName + "-location"));
 				locations.put(location);


### PR DESCRIPTION
The composite order endpoint tracks quantity as `quantityPhysical` under
cost and locations objects. Previously we were hardcoding the value
under cost to `1`, while dynamically setting the value under locations
based on the `980$g` in the MARC record.

Now, both are set dynamically via the `980$g` and remain in sync, thus
avoiding the `physicalLocCostQtyMismatch` error when POSTing the
composite order.

> "PO Line physical quantity and Locations physical quantity do not
> match"