### PR TITLE
Add `inventory-storage.items.collection.get` perm

### DIFF
--- a/folio-permset.json
+++ b/folio-permset.json
@@ -17,6 +17,7 @@
     "inventory-storage.holdings-types.collection.get",
     "inventory-storage.identifier-types.collection.get",
     "inventory-storage.instance-types.collection.get",
+    "inventory-storage.items.collection.get",
     "inventory-storage.loan-types.collection.get",
     "inventory-storage.locations.collection.get",
     "inventory-storage.material-types.collection.get",


### PR DESCRIPTION
Needed for `GET` on `inventory/instances/{id}` as of Juniper release. Didn't track it down to the root cause, but commented on [MODINV-492](https://issues.folio.org/browse/MODINV-492) seeking clarification.

Hat tip to @damien-git for identifying and reporting this bug.