### PR TITLE
Set default expense class for all POLs

### DIFF
--- a/src/main/java/org/olf/folio/order/Constants.java
+++ b/src/main/java/org/olf/folio/order/Constants.java
@@ -10,5 +10,6 @@ public class Constants {
     public static final String BILLINGMAP = "billingMap";
     public static final String COPYCAT_DEFAULT_PROFILE = "4c41105d-a3cc-4f2a-8106-aeee2d30ffd0";
     public static final String COPYCAT_SHELFREADY_PROFILE = "87592fe9-5b0e-43d2-a0da-13a76e6d0262";
+    public static final String EXPENSE_CLASS = "1394daf5-01af-4f7f-bcac-2e9011aaec47";
     public static final String LOOKUP_TABLE = "lookupTable";
 }

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -372,6 +372,7 @@ public class OrderImport {
 				JSONObject fundDist = new JSONObject();
 				fundDist.put("code", fundCode);
 				fundDist.put("fundId", fundId);
+				fundDist.put("expenseClassId", Constants.EXPENSE_CLASS);
 				fundDist.put("distributionType", "percentage");
 				fundDist.put("value", 100);
 				funds.put(fundDist);


### PR DESCRIPTION
Within POL fundDistribution object, default expense class to `Physical
Res - one-time perpetual` for all POs created via the Lehigh App.

* Resolves #88.