### PR TITLE
Add Holdings count per POL to results

### DIFF
--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -458,9 +458,14 @@ public class OrderImport {
                         isbnList.add((String) productIdObj.get("productId"));
                     }
 				}
+
+        String holdings = apiService.callApiGet(baseOkapEndpoint + "holdings-storage/holdings?limit=0&query=(instanceId==" + instanceId + ")", token);
+				JSONObject holdingsJson = new JSONObject(holdings);
+        int holdingsCount = (int) holdingsJson.get("totalRecords");
 				
 				responseMessage.put("poLineUUID", poLineUUID);
 				responseMessage.put("poLineNumber", poLineNumber);
+				responseMessage.put("holdingsCount", holdingsCount);
 				responseMessage.put("title", title);
 				responseMessage.put("requester", requester);
 				responseMessage.put("internalNote", internalNote);

--- a/src/main/webapp/WEB-INF/upload-order.jsp
+++ b/src/main/webapp/WEB-INF/upload-order.jsp
@@ -45,6 +45,17 @@
 	color: #a94442 !important;
 }
 
+.holdingsCount {
+  margin-left: 1em;
+  padding: 0.4em;
+  background: #7e3bda;
+  border-radius: 0.3em;
+  color: #fff;
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 0.8em;
+}
+
 .metadata {
   margin: .4em 0;
   padding-left: .6em;
@@ -283,7 +294,7 @@ function showname() {
         {{error}}
       {{else}}
         <dl>
-          <dt><a href="${baseFolioUrl}orders/lines/view/{{poLineUUID}}" title="View this PO Line in FOLIO Orders app" target="_blank">{{poLineNumber}}</a></dt>
+          <dt><a href="${baseFolioUrl}orders/lines/view/{{poLineUUID}}" title="View this PO Line in FOLIO Orders app" target="_blank">{{poLineNumber}}</a> <span class="holdingsCount">{{holdingsCount}} Holdings</span></dt>
           <dd><a href="${baseFolioUrl}inventory/view/{{instanceUUID}}" title="View this Instance in FOLIO Inventory app" target="_blank">{{title}}</a></dd>
           <dd class="metadata">{{instanceHrid}}</dd>
           <dd class="metadata">{{isbn}}</dd>


### PR DESCRIPTION
In an effort to streamline Orders team workflow, reducing the number of
click throughs to FOLIO Inventory to inspect for duplicates.

* Resolves #71

Double submitted the same file on `test` for demo purposes...

### Submit 1
![Screenshot 2022-03-18 at 17-12-34 Purchase Order Upload](https://user-images.githubusercontent.com/409842/159085570-2dcf7130-7ad4-429b-868a-0a1d9e1e0875.png)

### Submit 2
![Screenshot 2022-03-18 at 17-15-00 Purchase Order Upload](https://user-images.githubusercontent.com/409842/159085595-90e85e08-8f51-49a2-8fcf-1040060199ff.png)

